### PR TITLE
Fix/metrics

### DIFF
--- a/training/metrics.py
+++ b/training/metrics.py
@@ -5,6 +5,7 @@ from transformers import pipeline, RobertaForQuestionAnswering
 from tokenizers import Tokenizer
 import numpy as np
 from typing import TypedDict
+from ..types.declarations import Metrics
 
 
 """
@@ -188,21 +189,13 @@ def f1(a_gold: str, a_pred: str) -> float:
     vars = __span_comparison_helper(a_gold, a_pred)
     return __f1(*vars)
   
-class MetricsDict(TypedDict):
-    """the scores reported for each record
-    and the dataset as a whole
-    """
-    f1: float
-    recall: float
-    precision: float
-
 def evaluate_model(
   model: RobertaForQuestionAnswering, 
   tokenizer: Tokenizer, 
   val_texts: list[str], 
   val_queries: list[str], 
   val_answers: list[dict]
-) -> MetricsDict:
+) -> Metrics:
   """Function that evaluates a model
   on a validation dataset
 
@@ -221,7 +214,7 @@ def evaluate_model(
   nlp = pipeline('question-answering', model=model, tokenizer=tokenizer, device = 0)
 
   # list of dictionaries with scores
-  results: list[MetricsDict] = []
+  results: list[Metrics] = []
   
   # iterate through records
   for context, question, answer in zip(val_texts, val_queries, val_answers):

--- a/types/declarations.py
+++ b/types/declarations.py
@@ -8,3 +8,11 @@ class Answers(TypedDict):
     answers_end: int 
     answers_start: int
     text: str
+
+class Metrics(TypedDict):
+    """the scores reported for each record
+    and the dataset as a whole
+    """
+    f1: float
+    recall: float
+    precision: float


### PR DESCRIPTION
# Extracted type definition 
In this pull request I extracted the type definition of MetricsDict from metrics.py to types/declarations. Also I renamed the type to Metrics to be consistent with the other declarations. 

## How to test 
Linting with ruff 
No unit tests
